### PR TITLE
DO-16: Replace travis ci by github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Devops study homework tests
+
+on: [pull_request, push, workflow_dispatch]
+
+jobs:
+  build-apps:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run homework tests
+      run: |
+        echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}"
+        # dirty hack to simulate travis behavior
+        export TRAVIS_PULL_REQUEST_BRANCH=${GITHUB_REF_NAME}
+        export TRAVIS_BRANCH=${GITHUB_REF_NAME}
+        curl https://raw.githubusercontent.com/express42/otus-homeworks/2019-02/run.sh | bash

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,0 +1,18 @@
+name: Slack Notification
+
+on:
+  workflow_run:
+    workflows: [Devops study homework tests]
+    types: [completed]
+
+jobs:
+  slack-notify:
+    name: Build status
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Slack Notification
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_COLOR: ${{ github.event.workflow_run.conclusion }}


### PR DESCRIPTION
# Add github actions as a main CI tool

There is a limitation in a Travis CI free plan: free plan is valid only for 30 day since activation

So we need to replace Travis CI by Github Actions. This is the first PR which creates similar to travis CI workflow via Github Actions